### PR TITLE
Remove too generic and unnecessary isItem definition in NSObject cate…

### DIFF
--- a/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPItem.h
+++ b/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPItem.h
@@ -28,9 +28,3 @@
 - (BOOL)isEqualToItem:(NUIPItem *)item;
 
 @end
-
-@interface NSObject (NUIPIsItem)
-
-- (BOOL)isItem;
-
-@end

--- a/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPItem.m
+++ b/NUIParse/Parsers/NUIPShiftReduceParsers/NUIPItem.m
@@ -76,14 +76,9 @@
     return [c autorelease];
 }
 
-- (BOOL)isItem
-{
-    return YES;
-}
-
 - (BOOL)isEqual:(id)object
 {
-    return [object isItem] && ((NUIPItem *)object)->position == position && ((NUIPItem *)object)->rule == rule;
+    return [object isKindOfClass:[NUIPItem class]] && [self isEqualToItem:object];
 }
 
 - (BOOL)isEqualToItem:(NUIPItem *)item
@@ -115,15 +110,6 @@
         [desc appendString:@"•"];
     }
     return desc;
-}
-
-@end
-
-@implementation NSObject (NUIPIsItem)
-
-- (BOOL)isItem
-{
-    return NO;
 }
 
 @end


### PR DESCRIPTION
It is against the objective-c best practices to define a method in a category with a generic name such as `isItem` on any class, but it is especially bad practice to do it so on the base class of all other classes, `NSObject`. It is very likely that it will lead to name clashes somewhere in the application as soon as anybody defines an own `isItem` method with another semantic. See also [Customizing Existing Classes / Avoid Category Method Clashes](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW4) in Apple's developer guide. 

In this particular case it is even unnecessary to define any method as the functionality can be achieved via `-[NSObject isKindOfClass:]`. 